### PR TITLE
[patch] Upgrade Facebook Graph API version from 2.6 to 2.7.

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -21,7 +21,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v2.6';
+    protected $version = 'v2.7';
 
     /**
      * The user fields being requested.


### PR DESCRIPTION
I don't know the significance of this, and the [original PR](https://github.com/laravel/socialite/pull/177) contains nothing more than what is the title of this PR.

It should be all right to use the 2.7 version, but I'll have a look at the changelog before I merge.
